### PR TITLE
Added .DS_Store to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ xcuserdata
 *.moved-aside
 *.xcuserstate
 *.xcscmblueprint
+.DS_Store
 
 ## Obj-C/Swift specific
 *.hmap


### PR DESCRIPTION
This is a common file added by Mac OSX that isn't in the default GitHub gitignore template.
